### PR TITLE
Implement: Show widget form controls initially in collapsed state

### DIFF
--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -31,7 +31,7 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 				</div>
 				<div class="widget-title">
 					<h4 class="customize-control-title">
-						<?php echo esc_html( $this->label ); ?>
+						<?php echo esc_html( $this->label ); ?><span class="in-widget-title"></span>
 					</h4>
 				</div>
 			</div>

--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -35,7 +35,6 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 					</h4>
 				</div>
 			</div>
-			<!-- need to remove display:block -->
 			<div class="customize-control-content widget-inside">
 				<fieldset class="widget-content">
 				<?php

--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -24,35 +24,45 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 		$multi_number = isset($sidebar_args['_multi_num']) ? $sidebar_args['_multi_num'] : '';
 		$add_new = '';
 		?>
-		<label>
-			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-		</label>
-		<div class="customize-control-content">
-			<fieldset class="widget-content">
-			<?php
-			if ( isset( $control['callback'] ) ) {
-				$has_form = call_user_func_array( $control['callback'], $control['params'] );
-			}
-			else {
-				echo "\t\t<p>" . __( 'There are no options for this widget.', 'widget-customizer' ) . "</p>\n";
-			}
-			?>
-			</fieldset>
-			<input type="hidden" name="widget-id" class="widget-id" value="<?php echo esc_attr( $this->widget_id ); ?>" />
-			<input type="hidden" name="id_base" class="id_base" value="<?php echo esc_attr($id_base); ?>" />
-			<input type="hidden" name="sidebar" class="sidebar" value="<?php echo esc_attr($this->sidebar_id); ?>" />
-			<input type="hidden" name="widget-width" class="widget-width" value="<?php if (isset( $control['width'] )) echo esc_attr($control['width']); ?>" />
-			<input type="hidden" name="widget-height" class="widget-height" value="<?php if (isset( $control['height'] )) echo esc_attr($control['height']); ?>" />
-			<input type="hidden" name="widget_number" class="widget_number" value="<?php echo esc_attr($widget_number); ?>" />
-			<input type="hidden" name="multi_number" class="multi_number" value="<?php echo esc_attr($multi_number); ?>" />
-			<input type="hidden" name="add_new" class="add_new" value="<?php echo esc_attr($add_new); ?>" />
-
-			<div class="widget-control-actions">
-				<div class="alignright<?php if ( 'noform' === $has_form ) echo ' widget-control-noform'; ?>">
-					<input type="button" name="updatewidget" id="updatewidget" class="button button-secondary widget-control-update right" value="<?php esc_attr_e( 'Update', 'widget-customizer' ) ?>">
-					<span class="spinner"></span>
+		<div class="widget">
+			<div class="widget-top">
+				<div class="widget-title-action">
+					<a class="widget-action"></a>
 				</div>
-				<br class="clear" />
+				<div class="widget-title">
+					<h4 class="customize-control-title">
+						<?php echo esc_html( $this->label ); ?>
+					</h4>
+				</div>
+			</div>
+			<!-- need to remove display:block -->
+			<div class="customize-control-content widget-inside">
+				<fieldset class="widget-content">
+				<?php
+				if ( isset( $control['callback'] ) ) {
+					$has_form = call_user_func_array( $control['callback'], $control['params'] );
+				}
+				else {
+					echo "\t\t<p>" . __( 'There are no options for this widget.', 'widget-customizer' ) . "</p>\n";
+				}
+				?>
+				</fieldset>
+				<input type="hidden" name="widget-id" class="widget-id" value="<?php echo esc_attr( $this->widget_id ); ?>" />
+				<input type="hidden" name="id_base" class="id_base" value="<?php echo esc_attr($id_base); ?>" />
+				<input type="hidden" name="sidebar" class="sidebar" value="<?php echo esc_attr($this->sidebar_id); ?>" />
+				<input type="hidden" name="widget-width" class="widget-width" value="<?php if (isset( $control['width'] )) echo esc_attr($control['width']); ?>" />
+				<input type="hidden" name="widget-height" class="widget-height" value="<?php if (isset( $control['height'] )) echo esc_attr($control['height']); ?>" />
+				<input type="hidden" name="widget_number" class="widget_number" value="<?php echo esc_attr($widget_number); ?>" />
+				<input type="hidden" name="multi_number" class="multi_number" value="<?php echo esc_attr($multi_number); ?>" />
+				<input type="hidden" name="add_new" class="add_new" value="<?php echo esc_attr($add_new); ?>" />
+
+				<div class="widget-control-actions">
+					<div class="alignright<?php if ( 'noform' === $has_form ) echo ' widget-control-noform'; ?>">
+						<input type="button" name="updatewidget" id="updatewidget" class="button button-secondary widget-control-update right" value="<?php esc_attr_e( 'Update', 'widget-customizer' ) ?>">
+						<span class="spinner"></span>
+					</div>
+					<br class="clear" />
+				</div>
 			</div>
 		</div>
 		<?php

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -9,3 +9,19 @@
 	-ms-user-select: none;
 	user-select: none;
 }
+
+.customize-control-widget_form .widget {
+	margin-bottom: 0;
+}
+
+.customize-control-widget_form .widget .widget-top {
+	cursor: default;
+}
+
+.customize-control-widget_form .widget .widget-top a {
+	cursor: pointer;
+}
+
+.customize-control-widget_form .widget-inside.visible {
+	display:block;
+}

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -21,7 +21,3 @@
 .customize-control-widget_form .widget .widget-top a {
 	cursor: pointer;
 }
-
-.customize-control-widget_form .widget-inside.visible {
-	display:block;
-}

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -26,6 +26,8 @@ var WidgetCustomizer = (function ($) {
 			control.setting.previewer.channel.bind( 'synced', function () {
 				control.container.removeClass( 'previewer-loading' );
 			});
+
+			control.controlTabs();
 		},
 
 		/**
@@ -68,11 +70,20 @@ var WidgetCustomizer = (function ($) {
 				control.container.find( '.widget-content' ).prop( 'disabled', false );
 				control.container.removeClass( 'widget-form-loading' );
 			});
+		},
+
+		controlTabs: function() {
+			$('.widget-top').click( function () {
+				$(this).next().toggleClass('visible');
+			});
 		}
+
 	});
 
 	// Note that 'widget_form' must match the Widget_Form_WP_Customize_Control::$type
 	customize.controlConstructor.widget_form = self.constuctor;
+
+
 
 	return self;
 }( jQuery ));

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -73,17 +73,28 @@ var WidgetCustomizer = (function ($) {
 		},
 
 		controlTabs: function() {
-			$('.widget-top').click( function () {
-				$(this).next().stop().slideToggle();
-			});
+			var control = this;
+			control.container.find('.widget-top').on( 'click', function (e) {
+				// Copied from wpWidgets.init() in wp-admin/js/widgets.js
+				var target = $(this);
+				var widget = target.closest('div.widget');
+				var inside = widget.children('.widget-inside');
+				if ( inside.is(':hidden') ) {
+					inside.slideDown('fast');
+				} else {
+					inside.slideUp('fast', function() {
+						widget.css({'width':'', margin:''});
+					});
+				}
+				e.preventDefault();
+			} );
+
 		}
 
 	});
 
 	// Note that 'widget_form' must match the Widget_Form_WP_Customize_Control::$type
 	customize.controlConstructor.widget_form = self.constuctor;
-
-
 
 	return self;
 }( jQuery ));

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -74,7 +74,7 @@ var WidgetCustomizer = (function ($) {
 
 		controlTabs: function() {
 			$('.widget-top').click( function () {
-				$(this).next().toggleClass('visible');
+				$(this).next().stop().slideToggle();
 			});
 		}
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -16,24 +16,26 @@ var WidgetCustomizer = (function ($) {
 			var control = this;
 
 			control.setting.bind( function( to ) {
-				control.update_widget( to );
+				control.updateWidget( to );
 			});
 
 			control.container.find( '.widget-control-update' ).on( 'click', function (e) {
-				control.update_widget();
+				control.updateWidget();
 			});
 
 			control.setting.previewer.channel.bind( 'synced', function () {
 				control.container.removeClass( 'previewer-loading' );
 			});
 
-			control.controlTabs();
+			control.setupControlToggle();
+
+			control.setupWidgetTitle();
 		},
 
 		/**
 		 * @param {object} instance_override  When the model changes, the instance is sent this way
 		 */
-		update_widget: function ( instance_override ) {
+		updateWidget: function ( instance_override ) {
 			var control = this;
 			var data = control.container.find(':input').serialize();
 			control.container.addClass( 'widget-form-loading' );
@@ -72,7 +74,7 @@ var WidgetCustomizer = (function ($) {
 			});
 		},
 
-		controlTabs: function() {
+		setupControlToggle: function() {
 			var control = this;
 			control.container.find('.widget-top').on( 'click', function (e) {
 				// Copied from wpWidgets.init() in wp-admin/js/widgets.js
@@ -88,9 +90,27 @@ var WidgetCustomizer = (function ($) {
 				}
 				e.preventDefault();
 			} );
+		},
 
+		setupWidgetTitle: function () {
+			var control = this;
+			control.setting.bind( function( to ) {
+				control.updateInWidgetTitle();
+			});
+			control.updateInWidgetTitle();
+		},
+
+		updateInWidgetTitle: function () {
+			var control = this;
+			var title = control.setting().title;
+			var in_widget_title = control.container.find('.in-widget-title');
+			if ( title ) {
+				in_widget_title.text( ': ' + title );
+			}
+			else {
+				in_widget_title.text( '' );
+			}
 		}
-
 	});
 
 	// Note that 'widget_form' must match the Widget_Form_WP_Customize_Control::$type


### PR DESCRIPTION
Adds accordion-style tabs to hide/show widget interface.  Causes jumpiness when widget tab expands down the page causing the scrollbar to appear.  Not sure what we can do about this without forcing the scrollbar at all times.

Fixes #7 
