### PR TITLE
Add support for deleting widgets and add keyboard-accessible way to expand/collapse widget form controls

### DIFF
--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -5,10 +5,6 @@
 	display: none; /* the link in here will fail if it ever gets used */
 }
 
-.customize-control-widget_form .widget-control-actions .alignleft {
-	display: none; /* We will show this again once we add Delete support */
-}
-
 .customize-control-widget_form.previewer-loading .spinner {
 	display: inline;
 }

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -126,6 +126,12 @@ var WidgetCustomizer = (function ($) {
 				control.collapseForm();
 			} );
 
+			control.container.find( '.widget-top a.widget-action' ).on( 'keydown', function(e) {
+				if ( 13 === e.which ){ 
+					this.click();
+				}
+			});
+
 			control.setting.previewer.channel.bind( 'synced', function () {
 				control.container.removeClass( 'previewer-loading' );
 			});

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -134,7 +134,7 @@ var WidgetCustomizer = (function ($) {
 			});
 
 			control.container.find( '.widget-top a.widget-action' ).on( 'keydown', function(e) {
-				if ( 13 === e.which ){ 
+				if ( 13 === e.which ){
 					this.click();
 				}
 			});
@@ -154,7 +154,7 @@ var WidgetCustomizer = (function ($) {
 		updateWidget: function ( instance_override, remove_widget ) {
 			var control = this;
 			var data = control.container.find(':input').serialize();
-			var removing = typeof remove_widget != 'undefined' && remove_widget;
+			var removing = typeof remove_widget !== 'undefined' && remove_widget;
 
 			control.container.addClass( 'widget-form-loading' );
 			control.container.addClass( 'previewer-loading' );
@@ -182,7 +182,7 @@ var WidgetCustomizer = (function ($) {
 						// @todo - there must be a better way to do this
 						// Remove references to the removed widget from wp.customize.settings 
 						var settings = customize.settings.settings['sidebars_widgets['+control.params.sidebar_id+']'];
-						settings.value.splice( settings.value.indexOf( control.params.widget_id ), 1 ); 
+						settings.value.splice( settings.value.indexOf( control.params.widget_id ), 1 );
 						delete customize.settings.settings[control.params.settings.default];
 					}
 					else{

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -342,7 +342,6 @@ class Widget_Customizer {
 
 			$id_base   = $_POST['id_base'];
 			$widget_id = $_POST['widget-id'];
-			$removing  = isset($_POST['remove_widget']) && $_POST['remove_widget'];
 
 			foreach ( (array) $wp_registered_widget_updates as $name => $control ) {
 
@@ -373,20 +372,13 @@ class Widget_Customizer {
 						$widget_obj->_set( $number );
 
 						$old_instance = isset($all_instances[$number]) ? $all_instances[$number] : array();
-						
-						if ( $removing ){
-							// false signals that the widget was removed
-							wp_send_json_success( array( 'instance' => false ) );
-							return;
-						}
-						else {
-							$instance = $widget_obj->update( $new_instance, $old_instance );
 
-							// filters the widget's settings before saving, return false to cancel saving (keep the old settings if updating)
-							$instance = apply_filters( 'widget_update_callback', $instance, $new_instance, $old_instance, $widget_obj );
-							if ( false !== $instance ) {
-								$all_instances[$number] = $instance;
-							}
+						$instance = $widget_obj->update( $new_instance, $old_instance );
+
+						// filters the widget's settings before saving, return false to cancel saving (keep the old settings if updating)
+						$instance = apply_filters( 'widget_update_callback', $instance, $new_instance, $old_instance, $widget_obj );
+						if ( false !== $instance ) {
+							$all_instances[$number] = $instance;
 						}
 
 						break; // run only once

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -379,7 +379,7 @@ class Widget_Customizer {
 							wp_send_json_success( array( 'instance' => false ) );
 							return;
 						}
-						else{
+						else {
 							$instance = $widget_obj->update( $new_instance, $old_instance );
 
 							// filters the widget's settings before saving, return false to cancel saving (keep the old settings if updating)
@@ -387,7 +387,6 @@ class Widget_Customizer {
 							if ( false !== $instance ) {
 								$all_instances[$number] = $instance;
 							}
-
 						}
 
 						break; // run only once

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -342,6 +342,7 @@ class Widget_Customizer {
 
 			$id_base   = $_POST['id_base'];
 			$widget_id = $_POST['widget-id'];
+			$removing  = isset($_POST['remove_widget']) && $_POST['remove_widget'];
 
 			foreach ( (array) $wp_registered_widget_updates as $name => $control ) {
 
@@ -372,13 +373,21 @@ class Widget_Customizer {
 						$widget_obj->_set( $number );
 
 						$old_instance = isset($all_instances[$number]) ? $all_instances[$number] : array();
+						
+						if ( $removing ){
+							// false signals that the widget was removed
+							wp_send_json_success( array( 'instance' => false ) );
+							return;
+						}
+						else{
+							$instance = $widget_obj->update( $new_instance, $old_instance );
 
-						$instance = $widget_obj->update( $new_instance, $old_instance );
+							// filters the widget's settings before saving, return false to cancel saving (keep the old settings if updating)
+							$instance = apply_filters( 'widget_update_callback', $instance, $new_instance, $old_instance, $widget_obj );
+							if ( false !== $instance ) {
+								$all_instances[$number] = $instance;
+							}
 
-						// filters the widget's settings before saving, return false to cancel saving (keep the old settings if updating)
-						$instance = apply_filters( 'widget_update_callback', $instance, $new_instance, $old_instance, $widget_obj );
-						if ( false !== $instance ) {
-							$all_instances[$number] = $instance;
 						}
 
 						break; // run only once


### PR DESCRIPTION
Addressing issues #26 & #22.  For #26, I think there is a better way to update the wp.customize object, but I'm not familiar with the api.  See @todo in widget-customizer.js.
