### PR TITLE
Add support for adding widgets

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -14,9 +14,10 @@ if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
 fi
 
 # JSHint
-if [ -e .jshintrc ]; then
+IFS=$'\n' staged_js_files=( $(git status --porcelain | egrep '^[MARC].+\.js$' | cut -c4-) )
+if [ -e .jshintrc ] && [ ${#staged_js_files[@]} != 0 ]; then
 	if command -v jshint >/dev/null 2>&1; then
-		jshint .
+		jshint "${staged_js_files[@]}"
 	else
 		echo "Skipping jshint since not installed"
 	fi

--- a/class-options-transaction.php
+++ b/class-options-transaction.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Allow changes to options to be logged and rolled back
+ */
+
+class Options_Transaction {
+
+	/**
+	 * @var array $options values updated while transaction is open
+	 */
+	public $options = array();
+
+	protected $_is_current = false;
+	protected $_operations = array();
+
+	/**
+	 * Determine whether or not the transaction is open
+	 * @return bool
+	 */
+	function is_current() {
+		return $this->_is_current;
+	}
+
+	/**
+	 * Get the number of operations performed in the transaction
+	 * @return bool
+	 */
+	function count() {
+		return count( $this->_operations );
+	}
+
+	/**
+	 * Start keeping track of changes to options, and cache their new values
+	 */
+	function start() {
+		$this->_is_current = true;
+		add_action( 'added_option', array( $this, '_capture_added_option' ), 10, 2 );
+		add_action( 'updated_option', array( $this, '_capture_updated_option' ), 10, 3 );
+		add_action( 'delete_option', array( $this, '_capture_pre_deleted_option' ), 10, 1 );
+		add_action( 'deleted_option', array( $this, '_capture_deleted_option' ), 10, 1 );
+	}
+
+	/**
+	 * @action added_option
+	 * @param $option_name
+	 * @param $new_value
+	 */
+	function _capture_added_option( $option_name, $new_value ) {
+		$this->options[$option_name] = $new_value;
+		$operation = 'add';
+		$this->_operations[] = compact( 'operation', 'option_name', 'new_value' );
+	}
+
+	/**
+	 * @action updated_option
+	 * @param string $option_name
+	 * @param mixed $old_value
+	 * @param mixed $new_value
+	 */
+	function _capture_updated_option( $option_name, $old_value, $new_value ) {
+		$this->options[$option_name] = $new_value;
+		$operation = 'update';
+		$this->_operations[] = compact( 'operation', 'option_name', 'old_value', 'new_value' );
+	}
+
+	protected $_pending_delete_option_autoload;
+	protected $_pending_delete_option_value;
+
+	/**
+	 * It's too bad the old_value and autoload aren't passed into the deleted_option action
+	 * @action delete_option
+	 * @param string $option_name
+	 */
+	function _capture_pre_deleted_option( $option_name ) {
+		global $wpdb;
+		$autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option_name ) );
+		$this->_pending_delete_option_autoload = $autoload;
+		$this->_pending_delete_option_value    = get_option( $option_name );
+	}
+
+	/**
+	 * @action deleted_option
+	 * @param string $option_name
+	 */
+	function _capture_deleted_option( $option_name ) {
+		unset( $this->options[$option_name] );
+		$operation = 'delete';
+		$old_value = $this->_pending_delete_option_value;
+		$autoload  = $this->_pending_delete_option_autoload;
+		$this->_operations[] = compact( 'operation', 'option_name', 'old_value', 'autoload' );
+	}
+
+	/**
+	 * Undo any changes to the options since start() was called
+	 */
+	function rollback() {
+		remove_action( 'updated_option', array( $this, '_capture_updated_option' ), 10, 3 );
+		remove_action( 'added_option', array( $this, '_capture_added_option' ), 10, 2 );
+		remove_action( 'delete_option', array( $this, '_capture_pre_deleted_option' ), 10, 1 );
+		remove_action( 'deleted_option', array( $this, '_capture_deleted_option' ), 10, 1 );
+		while ( 0 !== count( $this->_operations ) ) {
+			$option_operation = array_pop( $this->_operations );
+			if ( 'add' === $option_operation['operation'] ) {
+				delete_option( $option_operation['option_name'] );
+			}
+			else if ( 'delete' === $option_operation['operation'] ) {
+				add_option( $option_operation['option_name'], $option_operation['old_value'], null, $option_operation['autoload'] );
+			}
+			else if ( 'update' === $option_operation['operation'] ) {
+				update_option( $option_operation['option_name'], $option_operation['old_value'] );
+			}
+			else {
+				throw new Exception( 'Unexpected operation' );
+			}
+		}
+		$this->_is_current = false;
+	}
+}

--- a/class-sidebar-widgets-wp-customize-control.php
+++ b/class-sidebar-widgets-wp-customize-control.php
@@ -16,26 +16,13 @@ class Sidebar_Widgets_WP_Customize_Control extends WP_Customize_Control {
 	}
 
 	public function render_content() {
-		global $wp_widget_factory;
-
-		$id    = 'customize-control-' . str_replace( '[', '-', str_replace( ']', '', $this->id ) );
-		$class = 'customize-control customize-control-' . $this->type;
-
 		?>
-		<li hidden id="<?php echo esc_attr( $id ); ?>" class="<?php echo esc_attr( $class ); ?>">
-			<!-- @todo https://github.com/x-team/wp-widget-customizer/issues/3
-			<label>
-				<span class="customize-control-title"><?php echo esc_html_e( 'Add widget:', 'widget-customizer' ); ?></span>
-				<select>
-					<option></option>
-					<?php foreach ( $wp_widget_factory->widgets as $class_name => $widget ): ?>
-						<option value="<?php echo esc_attr( $class_name ) ?>"><?php echo esc_html( $widget->name ) ?></option>
-					<?php endforeach; ?>
-				</select>
-			</label>
-			-->
-		</li>
-
+		<label>
+			<span class="customize-control-title"><?php esc_html_e( 'Add widget:', 'widget-customizer' ); ?></span>
+		</label>
+		<select class="widefat available-widgets">
+			<option disabled><?php esc_html_e( 'Add widget...', 'widget-customizer' ) ?></option>
+		</select>
 		<?php
 	}
 }

--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -6,18 +6,19 @@
 class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 	public $type = 'widget_form';
 	public $widget_id;
+	public $widget_id_base;
 	public $sidebar_id;
 
 	public function to_json() {
 		parent::to_json();
-		$exported_properties = array( 'widget_id', 'sidebar_id' );
+		$exported_properties = array( 'widget_id', 'widget_id_base', 'sidebar_id' );
 		foreach ( $exported_properties as $key ) {
 			$this->json[$key] = $this->$key;
 		}
 	}
 
 	public function render_content() {
-		global $wp_registered_widgets, $wp_registered_widget_controls;
+		global $wp_registered_widgets;
 		require_once ABSPATH . '/wp-admin/includes/widgets.php';
 
 		$widget = $wp_registered_widgets[$this->widget_id];
@@ -25,16 +26,10 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 			$widget['params'][0] = array();
 		}
 
-		$sidebar = is_active_widget( $widget['callback'], $widget['id'], false, false );
-
 		$args = array(
 			'widget_id' => $widget['id'],
 			'widget_name' => $widget['name'],
 		);
-
-		if ( isset($wp_registered_widget_controls[$widget['id']]['id_base']) && isset($widget['params'][0]['number']) ) {
-			$id_base = $wp_registered_widget_controls[$widget['id']]['id_base'];
-		}
 
 		$args = wp_list_widget_controls_dynamic_sidebar( array( 0 => $args, 1 => $widget['params'][0] ) );
 

--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -17,7 +17,7 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 	}
 
 	public function render_content() {
-		global $wp_registered_widgets;
+		global $wp_registered_widgets, $wp_registered_widget_controls;
 		require_once ABSPATH . '/wp-admin/includes/widgets.php';
 
 		$widget = $wp_registered_widgets[$this->widget_id];
@@ -25,7 +25,19 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 			$widget['params'][0] = array();
 		}
 
-		$args = array( 'widget_id' => $widget['id'], 'widget_name' => $widget['name'] );
+		$sidebar = is_active_widget( $widget['callback'], $widget['id'], false, false );
+
+		$args = array(
+			'widget_id' => $widget['id'],
+			'widget_name' => $widget['name'],
+		);
+
+		if ( isset($wp_registered_widget_controls[$widget['id']]['id_base']) && isset($widget['params'][0]['number']) ) {
+			$id_base = $wp_registered_widget_controls[$widget['id']]['id_base'];
+			$args['_temp_id']   = "$id_base-__i__";
+			$args['_multi_num'] = next_widget_id_number( $id_base );
+		}
+
 		$args = wp_list_widget_controls_dynamic_sidebar( array( 0 => $args, 1 => $widget['params'][0] ) );
 		call_user_func_array( 'wp_widget_control', $args );
 	}

--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -34,11 +34,10 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 
 		if ( isset($wp_registered_widget_controls[$widget['id']]['id_base']) && isset($widget['params'][0]['number']) ) {
 			$id_base = $wp_registered_widget_controls[$widget['id']]['id_base'];
-			$args['_temp_id']   = "$id_base-__i__";
-			$args['_multi_num'] = next_widget_id_number( $id_base );
 		}
 
 		$args = wp_list_widget_controls_dynamic_sidebar( array( 0 => $args, 1 => $widget['params'][0] ) );
+
 		call_user_func_array( 'wp_widget_control', $args );
 	}
 }

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -57,7 +57,7 @@ var WidgetCustomizerPreview = (function ($) {
 			$(selector).attr( 'title', self.i18n.widget_tooltip );
 
 			$(document).on( 'mouseenter', selector, function () {
-				var control = parent.WidgetCustomizer.getControlInstanceForWidget( $(this).prop('id') );
+				var control = parent.WidgetCustomizer.getWidgetFormControlForWidget( $(this).prop('id') );
 				if ( control ) {
 					control.highlightSectionAndControl();
 				}
@@ -65,7 +65,7 @@ var WidgetCustomizerPreview = (function ($) {
 
 			// @todo click can interfere with interacting with the widget in the preview window; better to make a EDIT link overlay appear when hovering over the widget?
 			$(document).on( 'click', selector, function () {
-				var control = parent.WidgetCustomizer.getControlInstanceForWidget( $(this).prop('id') );
+				var control = parent.WidgetCustomizer.getWidgetFormControlForWidget( $(this).prop('id') );
 				if ( control ) {
 					control.expandControlSection();
 					control.expandForm();

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -1,4 +1,4 @@
-.customize-control-sidebar_widgets {
+.customize-control-sidebar_widgets label {
 	display: none;
 }
 .customize-control-sidebar_widgets .hide-if-js {

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -86,6 +86,11 @@ var WidgetCustomizer = (function ($) {
 				// Re-sort widget form controls
 				control.section_content.append( final_control_containers );
 
+				// If the widget was dragged into the sidebar, make sure the sidebar_id param is updated
+				_( widget_form_controls ).each( function ( widget_form_control ) {
+					widget_form_control.params.sidebar_id = control.params.sidebar_id;
+				} );
+
 				// Delete any widget form controls for removed widgets
 				_( removed_widget_ids ).each( function ( removed_widget_id ) {
 					var removed_control = self.getWidgetFormControlForWidget( removed_widget_id );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -125,6 +125,7 @@ var WidgetCustomizer = (function ($) {
 				$(this).parents('.customize-control').slideToggle(function(){
 					this.remove();
 					control.updatePreview();
+					// @todo If removed widget was single (not a multi widget) then we now need to make any single widget available for adding
 				});
 				return false;
 			});

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -155,24 +155,17 @@ var WidgetCustomizer = (function ($) {
 		},
 
 		/**
-		 * Listed for clicks on the .widget-control-remove link
+		 * Listen for clicks on the .widget-control-remove link
 		 */
 		setupDeletion: function(){
 			var control = this;
-
-			var remove_btn = control.control_section.find( 'a.widget-control-remove' );
-
-			remove_btn.text( self.i18n.remove_btn_label ); // wp_widget_control() outputs the link as "Delete"
-			remove_btn.attr( 'title', self.i18n.remove_btn_tooltip );
-
-			remove_btn.on( 'click', function(e){
+			control.control_section.on( 'click', '.widget-control-remove', function (e) {
 				e.preventDefault();
-				$(this).parents('.customize-control').slideToggle(function(){
-					this.remove();
+				$(this).closest('.customize-control').slideUp(function (){
+					$(this).remove();
 					control.updatePreview();
 					// @todo If removed widget was single (not a multi widget) then we now need to make any single widget available for adding
 				});
-				return false;
 			});
 		}
 
@@ -203,6 +196,10 @@ var WidgetCustomizer = (function ($) {
 				e.preventDefault();
 				control.collapseForm();
 			} );
+
+			var remove_btn = control.container.find( 'a.widget-control-remove' );
+			remove_btn.text( self.i18n.remove_btn_label ); // wp_widget_control() outputs the link as "Delete"
+			remove_btn.attr( 'title', self.i18n.remove_btn_tooltip );
 
 			control.container.find( '.widget-top a.widget-action' ).on( 'keydown', function(e) {
 				if ( 13 === e.which ){

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -92,6 +92,12 @@ var WidgetCustomizer = (function ($) {
 					if ( ! removed_control ) {
 						return;
 					}
+
+					// Detect if widget dragged to another sidebar and abort
+					if ( ! $.contains( control.section_content, removed_control.container ) ) {
+						return;
+					}
+
 					wp.customize.control.remove( removed_control.id );
 					removed_control.container.remove();
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -99,7 +99,7 @@ var WidgetCustomizer = (function ($) {
 					}
 
 					// Detect if widget dragged to another sidebar and abort
-					if ( ! $.contains( control.section_content, removed_control.container ) ) {
+					if ( ! $.contains( control.section_content[0], removed_control.container[0] ) ) {
 						return;
 					}
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -8,7 +8,7 @@ var WidgetCustomizer = (function ($) {
 		update_widget_nonce_value: null,
 		update_widget_nonce_post_key: null,
 		i18n: {},
-		available_widgets: [] // @todo Needs to be a Backbone collection
+		available_widgets: []
 	};
 	$.extend(self, WidgetCustomizer_exports);
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -75,6 +75,7 @@ var WidgetCustomizer = (function ($) {
 
 			/**
 			 * Update ordering of widget control forms when the setting is updated
+			 * @todo This is not relevant to sortable now but is general, and should go up to ready()
 			 */
 			control.setting.bind( function( new_widget_ids, old_widget_ids ) {
 
@@ -109,10 +110,19 @@ var WidgetCustomizer = (function ($) {
 				// Delete any widget form controls for removed widgets
 				_( removed_widget_ids ).each( function ( removed_widget_id ) {
 					var removed_control = self.getWidgetFormControlForWidget( removed_widget_id );
-					if ( removed_control ) {
-						wp.customize.control.remove( removed_control.id );
-						removed_control.container.remove();
+					if ( ! removed_control ) {
+						return;
 					}
+					wp.customize.control.remove( removed_control.id );
+
+					removed_control.container.remove();
+
+					// Make old single widget available for adding again
+					var widget = self.available_widgets.findWhere({ id_base: removed_control.params.widget_id_base });
+					if ( widget && ! widget.get( 'is_multi' ) ) {
+						widget.set( 'is_disabled', false );
+					}
+
 				} );
 			});
 
@@ -235,6 +245,7 @@ var WidgetCustomizer = (function ($) {
 					},
 					sidebar_id: control.sidebar_id,
 					widget_id: widget_id,
+					widget_id_base: widget.get( 'id_base' ),
 					type: customize_control_type
 				},
 				previewer: control.setting.previewer
@@ -326,7 +337,6 @@ var WidgetCustomizer = (function ($) {
 					}
 					sidebar_widget_ids.splice( i, 1 );
 					sidebars_widgets_control.setting( sidebar_widget_ids );
-					// @todo When removing a widget from sidebars_widgets_control.setting(), it should automatically remove the widget form control from the sidebar
 				});
 			} );
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -178,6 +178,10 @@ var WidgetCustomizer = (function ($) {
 			customize_control.addClass( 'customize-control' );
 			customize_control.addClass( 'customize-control-' + customize_control_type );
 			customize_control.append( $(control_html) );
+			if ( widget.get( 'is_multi' ) ) {
+				customize_control.find( 'input[name="widget_number"]' ).val( multi_number );
+				customize_control.find( 'input[name="multi_number"]' ).val( multi_number );
+			}
 			customize_control.hide();
 			widget_id = customize_control.find('[name="widget-id"]' ).val();
 
@@ -208,10 +212,16 @@ var WidgetCustomizer = (function ($) {
 			} );
 			wp.customize.control.add( setting_id, widget_form_control );
 
+			var sidebar_widgets = control.setting();
+			sidebar_widgets.unshift( widget_id );
+			control.setting( sidebar_widgets );
+
 			customize_control.slideDown(function () {
 				widget_form_control.expandForm();
 				widget_form_control.container.find( '.widget-inside :input:first' ).focus();
 			});
+
+			widget_form_control.updateWidget();
 		},
 
 		/**

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -47,38 +47,17 @@ var WidgetCustomizer = (function ($) {
 			var control = this;
 			control.control_section = control.container.closest( '.control-section' );
 			control.section_content = control.container.closest( '.accordion-section-content' );
+			control.setupModel();
 			control.setupSortable();
 			control.setupAddition();
 		},
 
 		/**
-		 * Allow widgets in sidebar to be re-ordered, and for the order to be previewed
+		 * Update ordering of widget control forms when the setting is updated
 		 */
-		setupSortable: function () {
+		setupModel: function() {
 			var control = this;
-
-			/**
-			 * Update widget order setting when controls are re-ordered
-			 */
-			control.section_content.sortable({
-				items: '> .customize-control-widget_form',
-				axis: 'y',
-				connectWith: '.accordion-section-content:has(.customize-control-sidebar_widgets)',
-				update: function () {
-					var widget_container_ids = control.section_content.sortable('toArray');
-					var widget_ids = $.map( widget_container_ids, function ( widget_container_id ) {
-						return $('#' + widget_container_id).find(':input[name=widget-id]').val();
-					});
-					control.setting( widget_ids );
-				}
-			});
-
-			/**
-			 * Update ordering of widget control forms when the setting is updated
-			 * @todo This is not relevant to sortable now but is general, and should go up to ready()
-			 */
 			control.setting.bind( function( new_widget_ids, old_widget_ids ) {
-
 				var removed_widget_ids = _( old_widget_ids ).difference( new_widget_ids );
 
 				var widget_form_controls = _( new_widget_ids ).map( function ( widget_id ) {
@@ -124,6 +103,29 @@ var WidgetCustomizer = (function ($) {
 					}
 
 				} );
+			});
+		},
+
+		/**
+		 * Allow widgets in sidebar to be re-ordered, and for the order to be previewed
+		 */
+		setupSortable: function () {
+			var control = this;
+
+			/**
+			 * Update widget order setting when controls are re-ordered
+			 */
+			control.section_content.sortable({
+				items: '> .customize-control-widget_form',
+				axis: 'y',
+				connectWith: '.accordion-section-content:has(.customize-control-sidebar_widgets)',
+				update: function () {
+					var widget_container_ids = control.section_content.sortable('toArray');
+					var widget_ids = $.map( widget_container_ids, function ( widget_container_id ) {
+						return $('#' + widget_container_id).find(':input[name=widget-id]').val();
+					});
+					control.setting( widget_ids );
+				}
 			});
 
 			/**

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -50,20 +50,6 @@ var WidgetCustomizer = (function ($) {
 			control.setupSortable();
 			control.setupAddition();
 		},
-		
-		/**
-		 * Update the preview window based on the current widgets, possibly having just be reordered, 
-		 * added to or removed from.
-		 * @todo This is should not be used too much. We need to rely on the model to drive the UI, not the other way around.
-		 */
-		updatePreview: function(){
-			var control = this;
-			var widget_container_ids = control.section_content.sortable('toArray');
-			var widget_ids = $.map( widget_container_ids, function ( widget_container_id ) {
-				return $('#' + widget_container_id).find(':input[name=widget-id]').val();
-			});
-			control.setting( widget_ids );
-		},
 
 		/**
 		 * Allow widgets in sidebar to be re-ordered, and for the order to be previewed
@@ -79,7 +65,11 @@ var WidgetCustomizer = (function ($) {
 				axis: 'y',
 				connectWith: '.accordion-section-content:has(.customize-control-sidebar_widgets)',
 				update: function () {
-					control.updatePreview(); // @todo we can inline the logic here because otherwise the widgets should get reordered via setting the model anyway
+					var widget_container_ids = control.section_content.sortable('toArray');
+					var widget_ids = $.map( widget_container_ids, function ( widget_container_id ) {
+						return $('#' + widget_container_id).find(':input[name=widget-id]').val();
+					});
+					control.setting( widget_ids );
 				}
 			});
 
@@ -207,12 +197,7 @@ var WidgetCustomizer = (function ($) {
 				widget.set( 'is_disabled', true ); // Prevent single widget from being added again now
 			}
 
-			// @todo Either create a widget_form control linked to existing setting, or add a new widget
-			// @todo Check if widget is multi, and if widget_number is empty, then need to increment multi_number and use it
-			// @todo Check to see if widget_id corresponds to an existing setting, and if so, do not increament multi_number
-
 			var customize_control_type = 'widget_form';
-
 			var customize_control = $('<li></li>');
 			customize_control.addClass( 'customize-control' );
 			customize_control.addClass( 'customize-control-' + customize_control_type );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -218,9 +218,16 @@ var WidgetCustomizer = (function ($) {
 				customize_control.find( 'input[name="widget_number"]' ).val( widget_number );
 				customize_control.find( 'input[name="multi_number"]' ).val( widget_number );
 			}
+
+			// We have to manually set this because the RSS widget will fail to output a proper template,
+			// so the __i__ replacement below will fail (it outputs 'rss-0')
+			if ( widget.get( 'is_multi' ) ) {
+				widget_id = widget_id_base + '-' + widget_number;
+			}
+			customize_control.find('[name="widget-id"]' ).val( widget_id );
+
 			customize_control.find( 'input[name="id_base"]' ).val( widget_id_base );
-			customize_control.hide();
-			widget_id = customize_control.find('[name="widget-id"]' ).val();
+			customize_control.hide(); // to be slid-down below
 
 			var setting_id = 'widget_' + widget.get('id_base');
 			if ( widget.get( 'is_multi' ) ) {

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -232,15 +232,7 @@ var WidgetCustomizer = (function ($) {
 				customize_control.find( 'input[name="widget_number"]' ).val( widget_number );
 				customize_control.find( 'input[name="multi_number"]' ).val( widget_number );
 			}
-
-			// We have to manually set this because the RSS widget will fail to output a proper template,
-			// so the __i__ replacement below will fail (it outputs 'rss-0')
-			if ( widget.get( 'is_multi' ) ) {
-				widget_id = widget_id_base + '-' + widget_number;
-			}
-			customize_control.find('[name="widget-id"]' ).val( widget_id );
-
-			customize_control.find( 'input[name="id_base"]' ).val( widget_id_base );
+			widget_id = customize_control.find('[name="widget-id"]' ).val();
 			customize_control.hide(); // to be slid-down below
 
 			var setting_id = 'widget_' + widget.get('id_base');

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -255,7 +255,7 @@ var WidgetCustomizer = (function ($) {
 			wp.customize.control.add( setting_id, widget_form_control );
 
 			// @todo make sure it has been removed from all other menus?
-			var sidebar_widgets = control.setting();
+			var sidebar_widgets = control.setting().slice();
 			if ( -1 === sidebar_widgets.indexOf( widget_id ) ) {
 				sidebar_widgets.unshift( widget_id );
 				control.setting( sidebar_widgets );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -25,6 +25,7 @@ var WidgetCustomizer = (function ($) {
 		is_multi: null,
 		multi_number: null,
 		name: null,
+		transport: 'refresh',
 		params: []
 		// @todo methods for adding and removing instances, and logic if ! is_multi
 	});

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -451,8 +451,20 @@ class Widget_Customizer {
 			do_action( 'widgets.php' );
 			do_action( 'sidebar_admin_setup' );
 
-			$id_base   = $_POST['id_base'];
-			$widget_id = $_POST['widget-id'];
+			$id_base      = $_POST['id_base'];
+			$widget_id    = $_POST['widget-id'];
+			$multi_number = ! empty( $_POST['multi_number'] ) ? (int) $_POST['multi_number'] : 0;
+			$settings     = isset( $_POST['widget-' . $id_base] ) && is_array( $_POST['widget-' . $id_base] ) ? $_POST['widget-' . $id_base] : false;
+
+			// Incoming is a new widget
+			if ( $settings && preg_match( '/__i__|%i%/', key( $settings ) ) ) {
+				if ( ! $multi_number ) {
+					throw new Widget_Customizer_Exception( $generic_error );
+				}
+
+				$_POST['widget-' . $id_base] = array( $multi_number => array_shift( $settings ) );
+				$widget_id = $id_base . '-' . $multi_number;
+			}
 
 			foreach ( (array) $wp_registered_widget_updates as $name => $control ) {
 
@@ -496,6 +508,10 @@ class Widget_Customizer {
 					}
 					break;
 				}
+			}
+
+			if ( ! empty( $_POST['add_new'] ) ) {
+				// @todo Do we need to bail?
 			}
 
 			/**

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -190,10 +190,11 @@ class Widget_Customizer {
 		wp_enqueue_script(
 			'widget-customizer',
 			self::get_plugin_path_url( 'widget-customizer.js' ),
-			array( 'jquery', 'customize-controls' ),
+			array( 'jquery', 'backbone', 'customize-controls' ),
 			self::get_version(),
 			true
 		);
+
 
 		// Why not wp_localize_script? Because we're not localizing, and it forces values into strings
 		global $wp_scripts;

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -293,6 +293,7 @@ class Widget_Customizer {
 			call_user_func_array( 'wp_widget_control', $list_widget_controls_args );
 			$control_tpl = ob_get_clean();
 
+			$setting_args = self::get_setting_args( self::get_setting_id( $widget['id'] ) );
 			// The properties here are mapped to the Backbone Widget model
 			$available_widget = array_merge(
 				$available_widget,
@@ -302,6 +303,7 @@ class Widget_Customizer {
 					'control_tpl' => $control_tpl,
 					'multi_number' => ( $args['_add'] === 'multi' ) ? $args['_multi_num'] : false,
 					'is_disabled' => $is_disabled,
+					'transport' => $setting_args['transport'],
 				)
 			);
 			$available_widgets[] = $available_widget;

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -269,12 +269,12 @@ class Widget_Customizer {
 				'_display' => 'template',
 			);
 
+			$is_disabled     = false;
 			$is_multi_widget = (
 				isset( $wp_registered_widget_controls[$widget['id']]['id_base'] )
 				&&
 				isset( $widget['params'][0]['number'] )
 			);
-			$is_hidden = false;
 			if ( $is_multi_widget ) {
 				$id_base = $wp_registered_widget_controls[$widget['id']]['id_base'];
 				$args['_temp_id']   = "$id_base-__i__";
@@ -284,7 +284,7 @@ class Widget_Customizer {
 			else {
 				$args['_add'] = 'single';
 				if ( $sidebar ) {
-					$is_hidden = true;
+					$is_disabled = true;
 				}
 			}
 
@@ -301,7 +301,7 @@ class Widget_Customizer {
 					'is_multi' => $is_multi_widget,
 					'control_tpl' => $control_tpl,
 					'multi_number' => ( $args['_add'] === 'multi' ) ? $args['_multi_num'] : false,
-					'is_hidden' => $is_hidden,
+					'is_disabled' => $is_disabled,
 				)
 			);
 			$available_widgets[] = $available_widget;
@@ -547,7 +547,7 @@ class Widget_Customizer {
 		}
 	}
 
-	protected static $transaction_cached_options = array();
+	protected static $transaction_cached_options    = array();
 	protected static $transaction_option_operations = array();
 
 	/**

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -617,19 +617,6 @@ class Widget_Customizer {
 				}
 			}
 			else {
-				// Fix up failure for RSS widget to properly convert temp_id (id_base-__i__), as the __i__
-				// gets casted to an int and so it comes out always id_base-0
-				$is_post_malformed = (
-					isset( $_POST['widget-' . $id_base] )
-					&& is_array( $_POST['widget-' . $id_base] )
-					&& isset( $_POST['widget-' . $id_base][0] )
-					&& ! isset( $_POST['widget-' . $id_base][$widget_number] )
-				);
-				if ( $is_post_malformed ) {
-					$_POST['widget-' . $id_base][$widget_number] = $_POST['widget-' . $id_base][0];
-					unset( $_POST['widget-' . $id_base][0] );
-				}
-
 				foreach ( (array) $wp_registered_widget_updates as $name => $control ) {
 					if ( $name === $id_base ) {
 						if ( ! is_callable( $control['callback'] ) ) {

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -235,6 +235,7 @@ class Widget_Customizer {
 							'section' => $section_id,
 							'sidebar_id' => $sidebar_id,
 							'widget_id' => $widget_id,
+							'widget_id_base' => $GLOBALS['wp_registered_widget_controls'][$widget_id]['id_base'],
 							'priority' => 10 + $i,
 						)
 					);
@@ -377,6 +378,7 @@ class Widget_Customizer {
 				if ( $sidebar ) {
 					$is_disabled = true;
 				}
+				$id_base = $widget['id'];
 			}
 
 			$list_widget_controls_args = wp_list_widget_controls_dynamic_sidebar( array( 0 => $args, 1 => $widget['params'][0] ) );

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -303,6 +303,7 @@ class Widget_Customizer {
 					'control_tpl' => $control_tpl,
 					'multi_number' => ( $args['_add'] === 'multi' ) ? $args['_multi_num'] : false,
 					'is_disabled' => $is_disabled,
+					'id_base' => $id_base,
 					'transport' => $setting_args['transport'],
 				)
 			);
@@ -506,7 +507,6 @@ class Widget_Customizer {
 						if ( ! is_callable( $control['callback'] ) ) {
 							continue;
 						}
-
 						ob_start();
 						call_user_func_array( $control['callback'], $control['params'] );
 						ob_end_clean();

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -167,16 +167,16 @@ class Widget_Customizer {
 			// Single widget
 			if ( false === $widget_number ) {
 				if ( false === $instance && empty( $value ) ) {
-					$value = array();
+					$instance = array();
 				}
 			}
 			// Multi widget
 			else if ( false === $instance || ! isset( $instance[$widget_number] ) ) {
-				if ( empty( $value ) ) {
-					$value = array( '_multiwidget' => 1 );
+				if ( empty( $instance ) ) {
+					$instance = array( '_multiwidget' => 1 );
 				}
-				if ( ! isset( $value[$widget_number] ) ) {
-					$value[$widget_number] = array();
+				if ( ! isset( $instance[$widget_number] ) ) {
+					$instance[$widget_number] = array();
 				}
 			}
 		}

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -92,6 +92,10 @@ class Widget_Customizer {
 			if ( ! isset( $GLOBALS['wp_registered_sidebars'][$sidebar_id] ) || 'wp_inactive_widgets' === $sidebar_id ) {
 				continue;
 			}
+
+			/**
+			 * Add section to contain control
+			 */
 			$section_id = sprintf( 'sidebar-widgets-%s', $sidebar_id );
 			$section_args = array(
 				'title' => sprintf(
@@ -107,15 +111,7 @@ class Widget_Customizer {
 			 * Add control for managing widgets in sidebar
 			 */
 			$setting_id = sprintf( 'sidebars_widgets[%s]', $sidebar_id );
-			$wp_customize->add_setting(
-				$setting_id,
-				array(
-					'type' => 'option',
-					'capability' => 'edit_theme_options',
-					'transport' => 'refresh',
-					// @todo add support for postMessage for some widgets; will need to use Ajax
-				)
-			);
+			$wp_customize->add_setting( $setting_id, self::get_setting_args( $setting_id ) );
 			$control = new Sidebar_Widgets_WP_Customize_Control(
 				$wp_customize,
 				$setting_id,
@@ -139,16 +135,7 @@ class Widget_Customizer {
 				preg_match( '/^(.*)-([0-9]+)$/', $widget_id, $matches ); // see private _get_widget_id_base()
 				$setting_id = sprintf( 'widget_%s[%s]', $matches[1], $matches[2] );
 				$registered_widget = $GLOBALS['wp_registered_widgets'][$widget_id];
-
-				$wp_customize->add_setting(
-					$setting_id,
-					array(
-						'type' => 'option',
-						'capability' => 'edit_theme_options',
-						'transport' => 'refresh',
-						// @todo add support for postMessage for some widgets; will need to use Ajax
-					)
-				);
+				$wp_customize->add_setting( $setting_id, self::get_setting_args( $setting_id ) );
 				$control = new Widget_Form_WP_Customize_Control(
 					$wp_customize,
 					$setting_id,
@@ -215,6 +202,22 @@ class Widget_Customizer {
 			'data',
 			sprintf( 'var WidgetCustomizer_exports = %s;', json_encode( $exports ) )
 		);
+	}
+
+	/**
+	 * @param string $id
+	 * @param array  [$overrides]
+	 * @return array
+	 */
+	static function get_setting_args( $id, $overrides = array() ) {
+		$args = array(
+			'type' => 'option',
+			'capability' => 'edit_theme_options',
+			'transport' => 'refresh',
+		);
+		$args = array_merge( $args, $overrides );
+		$args = apply_filters( 'widget_customizer_setting_args', $args, $id );
+		return $args;
 	}
 
 	/**

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -592,6 +592,21 @@ class Widget_Customizer {
 					$option = $instance_override;
 				}
 				update_option( $option_name, $option );
+
+				// Delete other $_POST fields to prevent old single widgets from obeying override
+				$preserved_keys = array(
+					'widget-id',
+					'id_base',
+					'widget-width',
+					'widget-height',
+					'widget_number',
+					'multi_number',
+					'add_new',
+					'action',
+				);
+				foreach ( array_diff( array_keys( $_POST ), $preserved_keys ) as $deleted_key ) {
+					unset( $_POST[$deleted_key] );
+				}
 			}
 			else {
 				foreach ( (array) $wp_registered_widget_updates as $name => $control ) {


### PR DESCRIPTION
It would be great if the great new widgets UI you're working on could be embedded within in a lightbox window that appears over the window when using the customizer (just like when you open the media manager). Widgets could then be dragged into the relevant customizer sections in the customizer panel (each sidebar could have its own section), and the preview window could then update to show the user what the site looks like with that widget added. 
- [x] Expand the widget control when it is first added to the sidebar.
- [x] Prepend the added widget to the existing widgets added to the sidebar. (Need to prepend the `widgets_sidebars` setting.)
- [x] Is WordPress keeping track of the multi_number outside of the widget form?
- [x] Don't invoke the widget save option when first adding a widget (to avoid error messages).
- [x] When removing a single widget, make option to add the widget enabled again.
- [x] Fix restoring of single widgets (has initial previewing state, and instance override does not work since control looks at `$_POST`)
- [x] When initially adding a widget, make sure it will appear in the preview even before saving.
- [x] When adding a single widget which previously existed (and is now in inactive sidebar), the old instance should remain.
- [x] Refactor all of this to eliminate PHP 5.3 dependencies
- [x] Remove pre-preview filters once `customize_register` happens
- [x] Refactor option transactions into separate class.
- [x] What is wrong with adding the RSS Feed widget?
- [x] Adding or reusing nonces for security? (e.g. in `preview_new_widgets`)
