### PR TITLE
Add facility for previewing changes in realtime with postMessage

### DIFF
--- a/theme-support/twentythirteen.js
+++ b/theme-support/twentythirteen.js
@@ -1,11 +1,7 @@
 /*global jQuery, wp */
 jQuery( function ($) {
 	wp.customize.bind( 'sidebar-updated', function ( sidebar_id ) {
-		if ( 'sidebar-1' !== sidebar_id ) {
-			return;
-		}
-
-		if ( $.isFunction( $.fn.masonry ) ) {
+		if ( 'sidebar-1' === sidebar_id && $.isFunction( $.fn.masonry ) ) {
 			var widget_area = $( '#secondary .widget-area' );
 			widget_area.masonry( 'reloadItems' );
 			widget_area.masonry();

--- a/theme-support/twentythirteen.js
+++ b/theme-support/twentythirteen.js
@@ -1,0 +1,14 @@
+/*global jQuery, wp */
+jQuery( function ($) {
+	wp.customize.bind( 'sidebar-updated', function ( sidebar_id ) {
+		if ( 'sidebar-1' !== sidebar_id ) {
+			return;
+		}
+
+		if ( $.isFunction( $.fn.masonry ) ) {
+			var widget_area = $( '#secondary .widget-area' );
+			widget_area.masonry( 'reloadItems' );
+			widget_area.masonry();
+		}
+	} );
+} );

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -1,4 +1,4 @@
-/*global jQuery, WidgetCustomizerPreview_exports */
+/*global jQuery, WidgetCustomizerPreview_exports, _, console */
 /*exported WidgetCustomizerPreview */
 var WidgetCustomizerPreview = (function ($) {
 	'use strict';
@@ -13,6 +13,7 @@ var WidgetCustomizerPreview = (function ($) {
 			this.buildWidgetSelectors();
 			this.toggleSections();
 			this.highlightControls();
+			this.livePreview();
 		},
 
 		/**
@@ -73,6 +74,27 @@ var WidgetCustomizerPreview = (function ($) {
 					control.container.find(':input:visible:first').focus();
 				}
 			});
+		},
+
+		/**
+		 *
+		 */
+		livePreview: function () {
+			$.each( self.initial_widget_setting_ids, function( i, setting_id ) {
+				wp.customize( setting_id, function( value ) {
+					var initial_value = value();
+					var update_count = 0;
+					value.bind( function( to ) {
+						// Workaround for http://core.trac.wordpress.org/ticket/26061;
+						// once fixed, eliminate initial_value, update_count, and this conditional
+						update_count += 1;
+						if ( 1 === update_count && _.isEqual( initial_value, to ) ) {
+							return;
+						}
+						console.info( 'TODO: AJAX', setting_id, to );
+					} );
+				} );
+			} );
 		}
 	};
 

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -347,25 +347,6 @@ var WidgetCustomizerPreview = (function ($) {
 	}
 
 	/**
-	 * @param {String} setting_id
-	 * @returns {String|null}
-	 */
-	function setting_id_to_widget_id( setting_id ) {
-		var widget_id = null;
-		var matches = setting_id.match(/^widget_(.+?)(?:\[(\d+)\])$/);
-		if ( ! matches ) {
-			return null;
-		}
-		if ( matches[2] ) {
-			widget_id = matches[1] + '-' + matches[2];
-		}
-		else {
-			widget_id = matches[1];
-		}
-		return widget_id;
-	}
-
-	/**
 	 * @param {String} sidebar_id
 	 * @returns {string}
 	 */

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -13,6 +13,7 @@ var WidgetCustomizerPreview = (function ($) {
 		render_widget_ajax_action: null,
 		render_widget_nonce_value: null,
 		render_widget_nonce_post_key: null,
+		preview: null,
 		i18n: {},
 
 		init: function () {
@@ -193,6 +194,7 @@ var WidgetCustomizerPreview = (function ($) {
 							}
 							else if ( ! new_widget.length && old_widget.length ) {
 								old_widget.remove();
+								// @todo if no more widgets are loaded in this sidebar, refresh preview
 							}
 							else if ( new_widget.length && ! old_widget.length ) {
 								var sidebar_widgets = wp.customize( sidebar_id_to_setting_id( r.data.sidebar_id ) )();
@@ -266,6 +268,7 @@ var WidgetCustomizerPreview = (function ($) {
 								if ( wp.customize.has( setting_id ) ) {
 									wp.customize.remove( setting_id );
 									// @todo WARNING: If a widget is moved to another sidebar, we need to either not do this, or force a refresh when a widget is  moved to another sidebar
+									// @todo if no more widgets are loaded in this sidebar, refresh preview
 								}
 								$( '#' + old_widget_id ).remove();
 
@@ -297,6 +300,17 @@ var WidgetCustomizerPreview = (function ($) {
 	};
 
 	$.extend(self, WidgetCustomizerPreview_exports);
+
+	/**
+	 * Capture the instance of the Preview since it is private
+	 */
+	var OldPreview = wp.customize.Preview;
+	wp.customize.Preview = OldPreview.extend( {
+		initialize: function( params, options ) {
+			self.preview = this;
+			OldPreview.prototype.initialize.call( this, params, options );
+		}
+	} );
 
 	/**
 	 * @param {String} widget_id

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -227,6 +227,8 @@ var WidgetCustomizerPreview = (function ($) {
 								}
 							}
 							self.preview.send( 'widget-updated', widget_id );
+							wp.customize.trigger( 'sidebar-updated', sidebar_id );
+							wp.customize.trigger( 'widget-updated', widget_id );
 							self.refreshTransports();
 						} );
 					} );
@@ -288,6 +290,7 @@ var WidgetCustomizerPreview = (function ($) {
 
 						// If a widget was removed so that no widgets remain rendered in sidebar, we need to disable postMessage
 						self.refreshTransports();
+						wp.customize.trigger( 'sidebar-updated', sidebar_id );
 					} );
 				} );
 			} );

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -272,7 +272,12 @@ var WidgetCustomizerPreview = (function ($) {
 							// Force the callback to fire if this widget is newly-added
 							if ( from.indexOf( widget_id ) === -1 ) {
 								self.refreshTransports();
-								setting.callbacks.fireWith( setting, [ setting(), null ] );
+								var parent_setting = parent.wp.customize( setting_id );
+								if ( 'postMessage' === parent_setting.transport ) {
+									setting.callbacks.fireWith( setting, [ setting(), null ] );
+								} else {
+									self.preview.send( 'refresh' );
+								}
 							}
 						} );
 

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -119,10 +119,10 @@ var WidgetCustomizerPreview = (function ($) {
 
 						$.post( wp.ajax.settings.url, data, function (r) {
 							// @todo We should tell the preview that synced has happened after the Ajax finishes
-							// @todo Inject into DOM, replacing existing element
 							// @todo Fire jQuery event to indicate that a widget was updated; here widgets can re-initialize them if they support live widgets
 							if ( r.success ) {
-
+								var widget = $( r.data.rendered_widget );
+								$( '#' + widget_id ).replaceWith( widget );
 							}
 							else {
 								var message = 'FAIL';

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -199,7 +199,6 @@ var WidgetCustomizerPreview = (function ($) {
 								throw new Error( r.data && r.data.message ? r.data.message : 'FAIL' );
 							}
 
-							// @todo We should tell the preview that synced has happened after the Ajax finishes
 							// @todo Fire jQuery event to indicate that a widget was updated; here widgets can re-initialize them if they support live widgets
 							var old_widget = $( '#' + widget_id );
 							var new_widget = $( r.data.rendered_widget );
@@ -227,6 +226,7 @@ var WidgetCustomizerPreview = (function ($) {
 									after_widget.before( new_widget );
 								}
 							}
+							self.preview.send( 'widget-updated', widget_id );
 							self.refreshTransports();
 						} );
 					} );

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -134,7 +134,22 @@ var WidgetCustomizerPreview = (function ($) {
 								old_widget.remove();
 							}
 							else if ( new_widget.length && ! old_widget.length ) {
-								// @todo Inject widget in the proper place
+								var sidebar_widgets = wp.customize('sidebars_widgets[' + r.data.sidebar_id + ']')();
+								var position = sidebar_widgets.indexOf( widget_id );
+								if ( -1 === position ) {
+									throw new Error( 'Unable to determine new widget position in sidebar' );
+								}
+								if ( sidebar_widgets.length === 1 ) {
+									throw new Error( 'Unexpected postMessage for adding first widget to sidebar; refresh must be used instead.' );
+								}
+								if ( position > 0 ) {
+									var before_widget = $( '#' + sidebar_widgets[ position - 1 ] );
+									before_widget.after( new_widget );
+								}
+								else {
+									var after_widget = $( '#' + sidebar_widgets[ position + 1 ] );
+									after_widget.before( new_widget );
+								}
 							}
 						} );
 					} );

--- a/widget-customizer-preview.js
+++ b/widget-customizer-preview.js
@@ -191,6 +191,12 @@ var WidgetCustomizerPreview = (function ($) {
 							return;
 						}
 
+						// Sort widgets
+						$.each( to, function ( i, widget_id ) {
+							var widget = $( '#' + widget_id );
+							widget.parent().append( widget );
+						} );
+
 						// Create settings for newly-created widgets
 						$.each( to, function ( i, widget_id ) {
 							var setting_id = widget_id_to_setting_id( widget_id );
@@ -215,8 +221,6 @@ var WidgetCustomizerPreview = (function ($) {
 								$( '#' + old_widget_id ).remove();
 							}
 						} );
-
-						// @todo Sort elements with IDs contained in the array `to`
 					} );
 				} );
 			} );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -583,12 +583,7 @@ var WidgetCustomizer = (function ($) {
 		 * Inside of the customizer preview, scroll the widget into view
 		 */
 		scrollPreviewWidgetIntoView: function () {
-			var control = this;
-			var widget_el = control.getPreviewWidgetElement();
 			// @todo scrollIntoView() provides a robust but very poor experience. Animation is needed. See https://github.com/x-team/wp-widget-customizer/issues/16
-			if ( widget_el.length ) {
-				widget_el[0].scrollIntoView( false );
-			}
 		},
 
 		/**

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -100,8 +100,13 @@ var WidgetCustomizer = (function ($) {
 				// Re-sort widget form controls
 				control.section_content.append( final_control_containers );
 
+				var must_refresh_preview = false;
+
 				// If the widget was dragged into the sidebar, make sure the sidebar_id param is updated
 				_( widget_form_controls ).each( function ( widget_form_control ) {
+					if ( widget_form_control.params.sidebar_id !== control.params.sidebar_id ) {
+						must_refresh_preview = true;
+					}
 					widget_form_control.params.sidebar_id = control.params.sidebar_id;
 				} );
 
@@ -131,6 +136,10 @@ var WidgetCustomizer = (function ($) {
 						widget.set( 'is_disabled', false );
 					}
 				} );
+
+				if ( must_refresh_preview ) {
+					self.previewer.refresh();
+				}
 			});
 		},
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -402,6 +402,7 @@ var WidgetCustomizer = (function ($) {
 				}
 			});
 
+			// @todo For transport=postMessage, the JS in the preview should send back an event so that this class can still be added
 			control.setting.previewer.channel.bind( 'synced', function () {
 				control.container.removeClass( 'previewer-loading' );
 			});
@@ -420,7 +421,10 @@ var WidgetCustomizer = (function ($) {
 			var data = control.container.find(':input').serialize();
 
 			control.container.addClass( 'widget-form-loading' );
-			control.container.addClass( 'previewer-loading' );
+			if ( 'refresh' === control.setting.transport ) {
+				// @todo The JS in the preview should send back an event so that this class can still be added
+				control.container.addClass( 'previewer-loading' );
+			}
 			control.container.find( '.widget-content' ).prop( 'disabled', true );
 
 			var params = {};

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -12,7 +12,8 @@ var WidgetCustomizer = (function ($) {
 		available_widgets: [],
 		sidebars_eligible_for_post_message: {},
 		widgets_eligible_for_post_message: {},
-		current_theme_supports: false
+		current_theme_supports: false,
+		previewer: null
 	};
 	$.extend(self, WidgetCustomizer_exports);
 
@@ -111,8 +112,9 @@ var WidgetCustomizer = (function ($) {
 						return;
 					}
 
-					// Detect if widget dragged to another sidebar and abort
+					// Detect if widget control was dragged to another sidebar and abort
 					if ( ! $.contains( control.section_content[0], removed_control.container[0] ) ) {
+						// @todo Trigger refresh?
 						return;
 					}
 
@@ -130,6 +132,8 @@ var WidgetCustomizer = (function ($) {
 						widget.set( 'is_disabled', false );
 					}
 				} );
+
+				// @todo if there was a widget in a sidebar, but it was just removed, we need to refresh the preview window
 			});
 		},
 
@@ -638,6 +642,18 @@ var WidgetCustomizer = (function ($) {
 
 		}
 	});
+
+	/**
+	 * Capture the instance of the Previewer since it is private
+	 */
+	var OldPreviewer = wp.customize.Previewer;
+	wp.customize.Previewer = OldPreviewer.extend( {
+		initialize: function( params, options ) {
+			self.previewer = this;
+			OldPreviewer.prototype.initialize.call( this, params, options );
+			this.bind( 'refresh', this.refresh );
+		}
+	} );
 
 	/**
 	 * Given a widget control, find the sidebar widgets control that contains it.

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -114,7 +114,6 @@ var WidgetCustomizer = (function ($) {
 
 					// Detect if widget control was dragged to another sidebar and abort
 					if ( ! $.contains( control.section_content[0], removed_control.container[0] ) ) {
-						// @todo Trigger refresh?
 						return;
 					}
 
@@ -132,8 +131,6 @@ var WidgetCustomizer = (function ($) {
 						widget.set( 'is_disabled', false );
 					}
 				} );
-
-				// @todo if there was a widget in a sidebar, but it was just removed, we need to refresh the preview window
 			});
 		},
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -412,10 +412,14 @@ var WidgetCustomizer = (function ($) {
 				}
 			});
 
-			// @todo For transport=postMessage, the JS in the preview should send back an event so that this class can still be added
 			control.setting.previewer.channel.bind( 'synced', function () {
 				control.container.removeClass( 'previewer-loading' );
 			});
+			self.previewer.bind( 'widget-updated', function ( updated_widget_id ) {
+				if ( updated_widget_id === control.params.widget_id ) {
+					control.container.removeClass( 'previewer-loading' );
+				}
+			} );
 
 			control.setupControlToggle();
 			control.setupWidgetTitle();
@@ -431,10 +435,7 @@ var WidgetCustomizer = (function ($) {
 			var data = control.container.find(':input').serialize();
 
 			control.container.addClass( 'widget-form-loading' );
-			if ( 'refresh' === control.setting.transport ) {
-				// @todo The JS in the preview should send back an event so that this class can still be added
-				control.container.addClass( 'previewer-loading' );
-			}
+			control.container.addClass( 'previewer-loading' );
 			control.container.find( '.widget-content' ).prop( 'disabled', true );
 
 			var params = {};

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -287,7 +287,7 @@ var WidgetCustomizer = (function ($) {
 					settings: {
 						'default': setting_id
 					},
-					sidebar_id: control.sidebar_id,
+					sidebar_id: control.params.sidebar_id,
 					widget_id: widget_id,
 					widget_id_base: widget.get( 'id_base' ),
 					type: customize_control_type

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -56,6 +56,7 @@ class Widget_Customizer {
 		'tewntyeleven' => false,
 		'tewntytwelve' => false,
 		'twentythirteen' => true,
+		'twentyfourteen' => false,
 	);
 
 	static function setup() {

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -46,6 +46,7 @@ class Widget_Customizer {
 		'tag_cloud',
 		'text',
 	);
+	protected static $initial_widget_setting_ids = array();
 
 	static function setup() {
 		self::load_textdomain();
@@ -316,6 +317,7 @@ class Widget_Customizer {
 				$id_base = $GLOBALS['wp_registered_widget_controls'][$widget_id]['id_base'];
 				$setting_args['transport'] = self::get_widget_setting_transport( $id_base );
 				$wp_customize->add_setting( $setting_id, $setting_args );
+				self::$initial_widget_setting_ids[] = $setting_id;
 
 				/**
 				 * Add control for widget if it is active
@@ -612,6 +614,7 @@ class Widget_Customizer {
 			'i18n' => array(
 				'widget_tooltip' => __( 'Edit widget in customizer...', 'widget-customizer' ),
 			),
+			'initial_widget_setting_ids' => self::$initial_widget_setting_ids,
 		);
 		$wp_scripts->add_data(
 			'widget-customizer-preview',
@@ -624,7 +627,9 @@ class Widget_Customizer {
 	 * At the very end of the page, at the very end of the wp_footer, communicate the sidebars that appeared on the page
 	 */
 	static function export_preview_data() {
+		global $wp_customize;
 		wp_print_scripts( array( 'widget-customizer-preview' ) );
+
 		?>
 		<script>
 		(function () {

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -552,14 +552,14 @@ class Widget_Customizer {
 	 * @return string
 	 */
 	static function get_widget_setting_transport( $id_base ) {
-		$transport = 'refresh';
+		$live_previewable = false;
 		if ( current_theme_supports( 'widget-customizer' ) && in_array( $id_base, self::$core_widget_base_ids ) ) {
-			$transport = 'postMessage';
+			$live_previewable = true;
 		}
 		// Allow widgets to opt-in for postMessage
-		$transport = apply_filters( 'customizer_widget_transport', $transport, $id_base );
-		$transport = apply_filters( "customizer_widget_transport_{$id_base}", $transport );
-		return $transport;
+		$live_previewable = apply_filters( 'customizer_widget_live_previewable', $live_previewable, $id_base );
+		$live_previewable = apply_filters( "customizer_widget_live_previewable_{$id_base}", $live_previewable );
+		return $live_previewable ? 'postMessage' : 'refresh';
 	}
 
 	/**
@@ -567,13 +567,13 @@ class Widget_Customizer {
 	 * @return string
 	 */
 	static function get_sidebar_widgets_setting_transport( $sidebar_id ) {
-		$transport = 'refresh';
+		$live_previewable = false;
 		if ( current_theme_supports( 'widget-customizer' ) ) {
-			$transport = 'postMessage';
+			$live_previewable = true;
 		}
-		$transport = apply_filters( 'customizer_sidebar_widgets_transport', $transport, $sidebar_id );
-		$transport = apply_filters( "customizer_sidebar_widgets_transport_{$sidebar_id}", $transport );
-		return $transport;
+		$live_previewable = apply_filters( 'customizer_sidebar_widgets_live_previewable', $live_previewable, $sidebar_id );
+		$live_previewable = apply_filters( "customizer_sidebar_widgets_live_previewable_{$sidebar_id}", $live_previewable );
+		return $live_previewable ? 'postMessage' : 'refresh';
 	}
 
 	/**

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -802,7 +802,7 @@ class Widget_Customizer {
 			$rendered_widget = ob_get_clean();
 
 			$options_transaction->rollback();
-			wp_send_json_success( compact( 'rendered_widget' ) );
+			wp_send_json_success( compact( 'rendered_widget', 'sidebar' ) );
 		}
 		catch ( Exception $e ) {
 			$options_transaction->rollback();


### PR DESCRIPTION
Making changes with Widget Customizer currently can be slow, and this is because each change results in a `refresh` of the preview window to see the change.

Re-ordering widgets should be possible completely with `postMessage`, as we can just rearrange the `.widget` elements. Likewise, widgets should be generally be deletable using `postMessage`. For adding or changing widgets, however, they may enqueue a script or style, or there may be some setup that expects the widget to be initialized once upon page load. So we cannot by default allow new widgets to be added or existing widgets to be changed, while using postMessage as the transport mechanism. However, there should be a facility in place for widgets to inform the customizer for how they _can_ be updated in realtime. The Widget Customizer can come bundled with `postMessage` handlers for all widgets that come with Core.

If using `postMessage`, we can also update widgets before having to wait for the user to click the widget's **Save** button. As such, if a widget has a `postMessage` handler, then the Save button should be hidden or disabled with the label changed to something like "Auto-saved".
- [x] Update widgets with postMessage
- [x] Insert new widgets into the preview when a new widget is added; will require dynamically binding to the newly-created values.
- [x] Allow widgets to be re-ordered with postMessage.
- [x] A theme may need to opt-in to postMessage widget updating via `add_theme_support()`
- [x] When removing the last widget from a sidebar so that none are left being rendered, must trigger a refresh
- [x] Allow widgets to be assigned to other sidebars with postMessage (or rather, fix it so it is not broken. A refresh is still needed due to changed sidebar args.)
- [x] Fire event when widget is updated with postMessage so plugin and theme can reinitialize if needed (e.g. Masonry in TwentyThirteen)
- [x] Require that widgets opt-in of supporting live previews. Add support for all core widgets.
- [x] Preview does not refresh when initially adding a widget that does not support live previews. Such a widget currently has to be forcibly updated to then appear. This is a problem for widgets that lack forms.
