### PR TITLE
Added 'farbtastic' to required scripts

### DIFF
--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -474,7 +474,7 @@ class Widget_Customizer {
 		wp_enqueue_script(
 			'widget-customizer',
 			self::get_plugin_path_url( 'widget-customizer.js' ),
-			array( 'jquery', 'backbone', 'wp-util', 'customize-controls' ),
+			array( 'jquery', 'backbone', 'wp-util', 'customize-controls', 'farbtastic' ),
 			self::get_version(),
 			true
 		);


### PR DESCRIPTION
I got some JS errors and noticed that 'farbtastic' wasn't being loaded. Added it as a requirement to 'widget-customizer'.
