### PR TITLE
Bugfix for handling keypress for available widgets

### DIFF
--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -857,7 +857,7 @@ var WidgetCustomizer = (function ($) {
 			$( '#available-widgets .widget-tpl' ).on( 'click keypress', function( event ) {
 
 				// Only proceed with keypress if it is Enter or Spacebar
-				if ( event.type === 'keydown' && ( event.which !== 13 && event.which !== 32 ) ) {
+				if ( event.type === 'keypress' && ( event.which !== 13 && event.which !== 32 ) ) {
 					return;
 				}
 


### PR DESCRIPTION
It intended that user can walk through available widgets (middle column in screenshot) by pressing up and down key. Thus, when user hit those keys, selection shoudn't be submit. There was bug in this condition check, and tshis PR fix it.

Tested on Firefox on Ubuntu. On Chrome, both new and old code works for whatever reason.

![available-widget](https://f.cloud.github.com/assets/2943548/1896183/f56046f4-7b86-11e3-888a-813198e84f1a.png)
