### PR TITLE
Proposal for supporting wide widget controls

### DIFF
--- a/class-widget-form-wp-customize-control.php
+++ b/class-widget-form-wp-customize-control.php
@@ -9,10 +9,13 @@ class Widget_Form_WP_Customize_Control extends WP_Customize_Control {
 	public $widget_id_base;
 	public $sidebar_id;
 	public $is_new = false;
+	public $width;
+	public $height;
+	public $is_wide = false;
 
 	public function to_json() {
 		parent::to_json();
-		$exported_properties = array( 'widget_id', 'widget_id_base', 'sidebar_id' );
+		$exported_properties = array( 'widget_id', 'widget_id_base', 'sidebar_id', 'width', 'height', 'is_wide' );
 		foreach ( $exported_properties as $key ) {
 			$this->json[$key] = $this->$key;
 		}

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -25,6 +25,10 @@
 }
 
 
+.wp-full-overlay-sidebar {
+	overflow: visible;
+}
+
 /**
  * Hide all sidebar sections by default, only show them (via JS) once the
  * preview loads and we know whether the sidebars are used in the template.
@@ -61,13 +65,35 @@
 
 .customize-control-widget_form .widget {
 	margin-bottom: 0;
+}
 
+.customize-control-widget_form:not(.wide-widget-control) {
 	/**
 	 * Prevent plugins (e.g. Widget Visibility in Jetpack) from forcing widget forms
 	 * to be wide and so overflow the customizer panel
 	 */
 	left: auto !important;
 	max-width: 100%;
+}
+.customize-control-widget_form.wide-widget-control .widget-inside {
+	position: fixed;
+	left: 300px;
+	top: 25%;
+	padding: 20px;
+	border: 1px solid rgb(229, 229, 229);
+	z-index: -1;
+
+	-webkit-transition: background 0.2s;
+	transition: background 0.2s;
+}
+.customize-control-widget_form.wide-widget-control.expanded:hover .widget-title {
+	background: #eee;
+}
+.customize-control-widget_form.wide-widget-control.expanded:hover .widget-inside {
+	background: #eee;
+}
+.customize-control-widget_form.wide-widget-control.expanded.focused-inside .widget-title {
+	background: #ddd;
 }
 
 .widget-inside {
@@ -78,6 +104,18 @@
 
 .widget-top {
 	cursor: move;
+}
+
+.customize-control-widget_form.expanded a.widget-action:after {
+	content: "\f142";
+}
+
+.customize-control-widget_form.wide-widget-control a.widget-action:after {
+	content: "\f139";
+}
+
+.customize-control-widget_form.wide-widget-control.expanded a.widget-action:after {
+	content: "\f141";
 }
 
 .widget-title-action {

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -82,22 +82,9 @@
 	padding: 20px;
 	border: 1px solid rgb(229, 229, 229);
 	z-index: -1;
-
-	-webkit-transition: background 0.2s;
-	transition: background 0.2s;
 }
 .customize-control-widget_form.wide-widget-control.collapsing .widget-inside {
 	z-index: -2;
-}
-
-.customize-control-widget_form.wide-widget-control.expanded:hover .widget-title {
-	background: #eee;
-}
-.customize-control-widget_form.wide-widget-control.expanded:hover .widget-inside {
-	background: #eee;
-}
-.customize-control-widget_form.wide-widget-control.expanded.focused-inside .widget-title {
-	background: #ddd;
 }
 
 .widget-inside {

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -86,6 +86,10 @@
 	-webkit-transition: background 0.2s;
 	transition: background 0.2s;
 }
+.customize-control-widget_form.wide-widget-control.collapsing .widget-inside {
+	z-index: -2;
+}
+
 .customize-control-widget_form.wide-widget-control.expanded:hover .widget-title {
 	background: #eee;
 }

--- a/widget-customizer.css
+++ b/widget-customizer.css
@@ -77,7 +77,7 @@
 }
 .customize-control-widget_form.wide-widget-control .widget-inside {
 	position: fixed;
-	left: 300px;
+	left: 299px;
 	top: 25%;
 	padding: 20px;
 	border: 1px solid rgb(229, 229, 229);
@@ -85,6 +85,15 @@
 }
 .customize-control-widget_form.wide-widget-control.collapsing .widget-inside {
 	z-index: -2;
+}
+
+.customize-control-widget_form.wide-widget-control .widget-top {
+	-webkit-transition: background-color 0.4s;
+	transition: background-color 0.4s;
+}
+.customize-control-widget_form.wide-widget-control.expanding .widget-top,
+.customize-control-widget_form.wide-widget-control.expanded:not(.collapsing) .widget-top {
+	background-color: rgb(227, 227, 227);
 }
 
 .widget-inside {

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -576,13 +576,6 @@ var WidgetCustomizer = (function ($) {
 					'min-height': control.params.height
 				} );
 			}
-			control.container.on( 'click keypress', function ( e ) {
-				$( '.customize-control-widget_form.focused-inside' ).not( control.container ).removeClass( 'focused-inside' );
-				var widget_inside = control.container.find( '.widget-inside:first' )[0];
-				if ( $.contains( widget_inside, e.target ) ) {
-					control.container.addClass( 'focused-inside' );
-				}
-			} );
 
 			// Configure update button
 			var save_btn = control.container.find( '.widget-control-save' );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -54,7 +54,9 @@ var WidgetCustomizer = (function ($) {
 		name: null,
 		id_base: null,
 		transport: 'refresh',
-		params: []
+		params: [],
+		width: null,
+		height: null
 	});
 	var WidgetCollection = self.WidgetCollection = Backbone.Collection.extend({
 		model: Widget
@@ -573,6 +575,12 @@ var WidgetCustomizer = (function ($) {
 				}
 			});
 
+			// Handle wide widgets
+			if ( control.params.is_wide ) {
+				control.container.addClass( 'wide-widget-control' );
+			}
+
+			// Configure update button
 			var save_btn = control.container.find( '.widget-control-save' );
 			save_btn.val( self.i18n.save_btn_label );
 			save_btn.attr( 'title', self.i18n.save_btn_tooltip );
@@ -582,6 +590,7 @@ var WidgetCustomizer = (function ($) {
 				control.updateWidget();
 			});
 
+			// Configure close button
 			var close_btn = control.container.find( '.widget-control-close' );
 			// @todo Hitting Enter on this link does nothing; will be resolved in core with <http://core.trac.wordpress.org/ticket/26633>
 			close_btn.on( 'click', function ( e ) {
@@ -590,6 +599,7 @@ var WidgetCustomizer = (function ($) {
 				control.container.find( '.widget-top .widget-action:first' ).focus(); // keyboard accessibility
 			} );
 
+			// Configure remove button
 			var remove_btn = control.container.find( 'a.widget-control-remove' );
 			// @todo Hitting Enter on this link does nothing; will be resolved in core with <http://core.trac.wordpress.org/ticket/26633>
 			remove_btn.on( 'click', function ( e ) {

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -578,7 +578,18 @@ var WidgetCustomizer = (function ($) {
 			// Handle wide widgets
 			if ( control.params.is_wide ) {
 				control.container.addClass( 'wide-widget-control' );
+				control.container.find( '.widget-content:first' ).css( {
+					'min-width': control.params.width,
+					'min-height': control.params.height
+				} );
 			}
+			control.container.on( 'click keypress', function ( e ) {
+				$( '.customize-control-widget_form.focused-inside' ).not( control.container ).removeClass( 'focused-inside' );
+				var widget_inside = control.container.find( '.widget-inside:first' )[0];
+				if ( $.contains( widget_inside, e.target ) ) {
+					control.container.addClass( 'focused-inside' );
+				}
+			} );
 
 			// Configure update button
 			var save_btn = control.container.find( '.widget-control-save' );
@@ -824,12 +835,22 @@ var WidgetCustomizer = (function ($) {
 			}
 			if ( do_expand ) {
 				control.container.trigger( 'expand' );
-				inside.slideDown( 'fast' );
+				if ( control.params.is_wide ) {
+					inside.animate({ width: 'show' });
+				} else {
+					inside.slideDown( 'fast' );
+				}
+				control.container.addClass( 'expanded' );
 			} else {
 				control.container.trigger( 'collapse' );
-				inside.slideUp( 'fast', function() {
-					widget.css( {'width':'', 'margin':''} );
-				} );
+				if ( control.params.is_wide ) {
+					inside.animate({ width: 'hide' });
+				} else {
+					inside.slideUp( 'fast', function() {
+						widget.css( {'width':'', 'margin':''} );
+					} );
+				}
+				control.container.removeClass( 'expanded' );
 			}
 		},
 

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -482,7 +482,10 @@ var WidgetCustomizer = (function ($) {
 					widget_id: widget_id,
 					widget_id_base: widget.get( 'id_base' ),
 					type: customize_control_type,
-					is_new: ! is_existing_widget
+					is_new: ! is_existing_widget,
+					width: widget.get( 'width' ),
+					height: widget.get( 'height' ),
+					is_wide: widget.get( 'is_wide' )
 				},
 				previewer: control.setting.previewer
 			} );
@@ -511,27 +514,17 @@ var WidgetCustomizer = (function ($) {
 				control.setting( sidebar_widgets );
 			}
 
-			var form_autofocus = function () {
-				var first_inside_input = widget_form_control.container.find( '.widget-inside :input:visible:first' );
-				if ( first_inside_input.length ) {
-					first_inside_input.focus();
-				} else {
-					widget_form_control.container.find( '.widget-top .widget-action:first' ).focus();
-				}
-			};
-
 			customize_control.slideDown(function () {
-				widget_form_control.expandForm();
-
 				if ( is_existing_widget ) {
+					widget_form_control.expandForm();
 					widget_form_control.updateWidget( widget_form_control.setting(), function ( error ) {
 						if ( error ) {
 							throw error;
 						}
-						form_autofocus();
+						widget_form_control.focus();
 					} );
 				} else {
-					form_autofocus();
+					widget_form_control.focus();
 				}
 			});
 
@@ -862,7 +855,7 @@ var WidgetCustomizer = (function ($) {
 			var control = this;
 			control.expandControlSection();
 			control.expandForm();
-			control.container.find( ':focusable:first' ).focus();
+			control.container.find( ':focusable:first' ).focus().trigger( 'click' );
 		},
 
 		/**

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -701,14 +701,9 @@ var WidgetCustomizer = (function ($) {
 			control.container.addClass( 'previewer-loading' );
 			control.container.find( '.widget-content' ).prop( 'disabled', true );
 
-			var parsed_widget_id = parse_widget_id( control.params.widget_id );
 			var params = {};
 			params.action = self.update_widget_ajax_action;
 			params[self.update_widget_nonce_post_key] = self.update_widget_nonce_value;
-			params['widget-id'] = control.params.widget_id;
-			params.id_base = parsed_widget_id.id_base;
-			params.widget_number = parsed_widget_id.number || '';
-			// @todo widget-width and widget-height?
 
 			var data = $.param( params );
 
@@ -717,6 +712,7 @@ var WidgetCustomizer = (function ($) {
 			} else {
 				data += '&' + control.container.find( '.widget-content' ).find( ':input' ).serialize();
 			}
+			data += '&' + control.container.find( '.widget-content ~ :input' ).serialize();
 
 			var jqxhr = $.post( wp.ajax.settings.url, data, function (r) {
 				if ( r.success ) {

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -792,13 +792,16 @@ var WidgetCustomizer = (function ($) {
 				widget_inside.css( 'top', top );
 			};
 
+			var theme_controls_container = $( '#customize-theme-controls' );
 			control.container.on( 'expand', function () {
 				customize_sidebar.on( 'scroll', position_widget );
 				$( window ).on( 'resize', position_widget );
+				theme_controls_container.on( 'expanded collapsed', position_widget );
 				position_widget();
 			} );
 			control.container.on( 'collapsed', function () {
 				customize_sidebar.off( 'scroll', position_widget );
+				theme_controls_container.off( 'expanded collapsed', position_widget );
 				$( window ).off( 'resize', position_widget );
 			} );
 
@@ -889,7 +892,7 @@ var WidgetCustomizer = (function ($) {
 					control.container.trigger( 'expanded' );
 				};
 				if ( control.params.is_wide ) {
-					inside.animate({ width: 'show' }, complete );
+					inside.animate( { width: 'show' }, 'fast', complete );
 				} else {
 					inside.slideDown( 'fast', complete );
 				}
@@ -902,10 +905,10 @@ var WidgetCustomizer = (function ($) {
 					control.container.trigger( 'collapsed' );
 				};
 				if ( control.params.is_wide ) {
-					inside.animate( { width: 'hide' }, complete );
+					inside.animate( { width: 'hide' }, 'fast', complete );
 				} else {
 					inside.slideUp( 'fast', function() {
-						widget.css( {'width':'', 'margin':''} );
+						widget.css( { width:'', margin:'' } );
 						complete();
 					} );
 				}

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -826,21 +826,43 @@ var WidgetCustomizer = (function ($) {
 			if ( typeof do_expand === 'undefined' ) {
 				do_expand = ! inside.is( ':visible' );
 			}
+
+			// Already expanded or collapsed, so noop
+			if ( control.container.hasClass( 'expanded' ) === do_expand ) {
+				return;
+			}
+
+			var complete;
 			if ( do_expand ) {
+				// Close all other widget controls before expanding this one
+				wp.customize.control.each( function ( other_control ) {
+					if ( control.params.type === other_control.params.type && control !== other_control ) {
+						other_control.collapseForm();
+					}
+				} );
+
 				control.container.trigger( 'expand' );
+				control.container.addClass( 'expanding' );
+				complete = function () {
+					control.container.removeClass( 'collapsing' );
+				};
 				if ( control.params.is_wide ) {
-					inside.animate({ width: 'show' });
+					inside.animate({ width: 'show' }, complete );
 				} else {
-					inside.slideDown( 'fast' );
+					inside.slideDown( 'fast', complete );
 				}
 				control.container.addClass( 'expanded' );
 			} else {
 				control.container.trigger( 'collapse' );
+				control.container.addClass( 'collapsing' );
+				complete = function () {
+					control.container.removeClass( 'collapsing' );
+				};
 				if ( control.params.is_wide ) {
-					inside.animate({ width: 'hide' });
+					inside.animate( { width: 'hide' }, complete );
 				} else {
 					inside.slideUp( 'fast', function() {
-						widget.css( {'width':'', 'margin':''} );
+						widget.css( {'width':'', 'margin':''}, complete );
 					} );
 				}
 				control.container.removeClass( 'expanded' );

--- a/widget-customizer.js
+++ b/widget-customizer.js
@@ -1369,6 +1369,14 @@ var WidgetCustomizer = (function ($) {
 		open: function ( sidebars_widgets_control ) {
 			var panel = this;
 			panel.active_sidebar_widgets_control = sidebars_widgets_control;
+
+			// Wide widget controls appear over the preview, and so they need to be collapsed when the panel opens
+			_( sidebars_widgets_control.getWidgetFormControls() ).each( function ( control ) {
+				if ( control.params.is_wide ) {
+					control.collapseForm();
+				}
+			} );
+
 			$( 'body' ).addClass( 'adding-widget' );
 			panel.container.find( '.widget-tpl' ).removeClass( 'selected' );
 			panel.filter_input.focus();

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -430,7 +430,8 @@ class Widget_Customizer {
 				} else {
 					self::$sidebars_eligible_for_post_message[$sidebar_id] = ( 'postMessage' === self::get_sidebar_widgets_setting_transport( $sidebar_id ) );
 				}
-				$setting_args['sanitize_callback'] = array( __CLASS__, 'sanitize_sidebar_widgets' );
+				$setting_args['sanitize_callback']    = array( __CLASS__, 'sanitize_sidebar_widgets' );
+				$setting_args['sanitize_js_callback'] = array( __CLASS__, 'sanitize_sidebar_widgets_js_instance' );
 				$wp_customize->add_setting( $setting_id, $setting_args );
 				$new_setting_ids[] = $setting_id;
 
@@ -1312,6 +1313,19 @@ class Widget_Customizer {
 			);
 		}
 		return $value;
+	}
+
+	/**
+	 * Strip out widget IDs for widgets which are no longer registered, such
+	 * as the case when a plugin orphans a widget in a sidebar when it is deactivated.
+	 *
+	 * @param array $widget_ids
+	 * @return array
+	 */
+	static function sanitize_sidebar_widgets_js_instance( $widget_ids ) {
+		global $wp_registered_widgets;
+		$widget_ids = array_values( array_intersect( $widget_ids, array_keys( $wp_registered_widgets ) ) );
+		return $widget_ids;
 	}
 
 	/**

--- a/widget-customizer.php
+++ b/widget-customizer.php
@@ -536,7 +536,7 @@ class Widget_Customizer {
 		global $wp_registered_widget_controls;
 		$parsed_widget_id = self::parse_widget_id( $widget_id );
 		$width = $wp_registered_widget_controls[$widget_id]['width'];
-		$is_core = in_array( $parsed_widget_id, self::$core_widget_id_bases );
+		$is_core = in_array( $parsed_widget_id['id_base'], self::$core_widget_id_bases );
 		$is_wide = ( $width > 250 && ! $is_core );
 		$is_wide = apply_filters( 'is_wide_widget_in_customizer', $is_wide, $widget_id );
 		return $is_wide;


### PR DESCRIPTION
When a wide widget control is collapsed, the triangle arrow that normally points downward instead points rightward:

> ![customize_twenty_thirteen__wordpress](https://f.cloud.github.com/assets/134745/2108574/6a59f176-8fe1-11e3-9e7a-8dedd853b60d.png)

When a wide widget control is expanded, the arrow switches to be leftward pointing, to indicate the direction it will collapse.

> ![customize_twenty_thirteen__wordpress-9](https://f.cloud.github.com/assets/134745/2108651/40dcde66-8fe2-11e3-9872-406b9cf0ba1e.png)

When you focus on a wide widget control, the corresponding `widget-top` will highlight to indicate which widget it is part of:

> ![customize_twenty_thirteen__wordpress](https://f.cloud.github.com/assets/134745/2108677/acd3416e-8fe2-11e3-966b-b9fbf4cb965a.png)

If there are multiple wide widget controls open at a time, hovering over the control or the widget title will indicate the two are connected:

> ![customize_twenty_thirteen__wordpress-4](https://f.cloud.github.com/assets/134745/2108683/cafc89b6-8fe2-11e3-94b3-3bff749d8f84.png)

Todos:
- [x] Ensure that newly-added wide widgets also properly initialize
- [x] Ensure that focused/hovered wide widget control has the higher `z-index`
- [x] Stop allowing multiple controls to be open at a time?
- [x] Position wide widget control vertically along with corresponding widget-top
- [ ] Allow wide widget control to be dragged to another location over the preview?
- [ ] Allow widget control to be made transparent to see through it?

Fixes #18 
